### PR TITLE
Automatically tune audio speed depending on audio buffer load

### DIFF
--- a/libretrodroid/src/main/cpp/CMakeLists.txt
+++ b/libretrodroid/src/main/cpp/CMakeLists.txt
@@ -26,6 +26,11 @@ add_library(libretrodroid SHARED
         renderers/es3/imagerendereres3.cpp
         audio.h
         audio.cpp
+        resamplers/resampler.h
+        resamplers/linearresampler.h
+        resamplers/linearresampler.cpp
+        resamplers/sincresampler.h
+        resamplers/sincresampler.cpp
         fpssync.h
         fpssync.cpp
         input.h

--- a/libretrodroid/src/main/cpp/CMakeLists.txt
+++ b/libretrodroid/src/main/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 
 # now build app's shared lib
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall")
 
 # Let's include oboe
 set (OBOE_DIR oboe)

--- a/libretrodroid/src/main/cpp/audio.cpp
+++ b/libretrodroid/src/main/cpp/audio.cpp
@@ -59,62 +59,15 @@ void LibretroDroid::Audio::write(const int16_t *data, size_t frames) {
     }
 }
 
-void LibretroDroid::Audio::resample_linear(const int16_t* source, int32_t inputFrames, int16_t* sink, int32_t sinkFrames) {
-    double outputTime = 0;
-    double outputTimeStep = 1.0 / sinkFrames;
-
-    double floatingPart, integerPart;
-
-    while (sinkFrames > 0) {
-        floatingPart = std::modf(outputTime * inputFrames, &integerPart);
-
-        int32_t floorFrame = integerPart;
-        int32_t ceilFrame = std::min(floorFrame + 1, inputFrames - 1);
-
-        *sink++ = source[ceilFrame * 2] * (floatingPart) + source[floorFrame * 2] * (1.0 - floatingPart);
-        *sink++ = source[ceilFrame * 2 + 1] * (floatingPart) + source[floorFrame * 2 + 1] * (1.0 - floatingPart);
-        outputTime += outputTimeStep;
-        sinkFrames--;
-    }
-}
-
-void LibretroDroid::Audio::resample_sinc(const int16_t* source, int32_t inputFrames, int16_t* sink, int32_t sinkFrames) {
-    float outputTime = 0;
-    float outputTimeStep = 1.0f / sinkFrames;
-
-    while (sinkFrames > 0) {
-        int32_t prevInputIndex = std::floor(outputTime * inputFrames);
-
-        int32_t leftResult = 0;
-        int32_t rightResult = 0;
-        float gain = 0.05;
-
-        auto startFrame = std::max(prevInputIndex - SINC_RESAMPLING_TAPS + 1, 0);
-        auto endFrame = std::min(prevInputIndex + SINC_RESAMPLING_TAPS, inputFrames - 1);
-
-        for (int32_t currentInputIndex = startFrame; currentInputIndex <= endFrame; currentInputIndex++) {
-            float sincCoefficient = sinc((outputTime * (inputFrames)) - (double) currentInputIndex);
-            gain += sincCoefficient;
-            leftResult += source[currentInputIndex * 2] * sincCoefficient;
-            rightResult += source[currentInputIndex * 2 + 1] * sincCoefficient;
-        }
-
-        outputTime += outputTimeStep;
-        *sink++ = leftResult / gain;
-        *sink++ = rightResult / gain;
-        sinkFrames--;
-    }
-}
-
 oboe::DataCallbackResult LibretroDroid::Audio::onAudioReady(oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) {
     double framesCapacityInBuffer = fifo->getBufferCapacityInFrames();
     double framesAvailableInBuffer = fifo->getFullFramesAvailable();
     double framesToMid = framesCapacityInBuffer - 2.0f * framesAvailableInBuffer;
 
-    double sampleRateAdjustment = 1 - MAX_AUDIO_ACCELERATION * framesToMid / framesCapacityInBuffer;
+    double sampleRateAdjustment = 1 - 2 * MAX_AUDIO_ACCELERATION * framesToMid / framesCapacityInBuffer;
     double finalSampleRate = defaultSampleRate * sampleRateAdjustment;
 
-    int32_t adjustedTotalFrames = std::floor(numFrames * finalSampleRate);
+    int32_t adjustedTotalFrames = numFrames * finalSampleRate;
 
     auto readFrames = fifo->readNow(audioBuffer.get(), adjustedTotalFrames * 2);
     if (readFrames != adjustedTotalFrames * 2) {
@@ -122,19 +75,6 @@ oboe::DataCallbackResult LibretroDroid::Audio::onAudioReady(oboe::AudioStream *o
     }
 
     auto outputArray = reinterpret_cast<int16_t *>(audioData);
-
-    auto start = std::chrono::high_resolution_clock::now();
-  //  resample_sinc(audioBuffer.get(), adjustedTotalFrames, outputArray, numFrames);
-    resample_linear(audioBuffer.get(), adjustedTotalFrames, outputArray, numFrames);
-    auto end = std::chrono::high_resolution_clock::now();
-
-    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-    LOGI("FILIPPO Resampling time: %d", duration.count());
-
+    resampler.resample(audioBuffer.get(), adjustedTotalFrames, outputArray, numFrames);
     return oboe::DataCallbackResult::Continue;
-}
-
-float LibretroDroid::Audio::sinc(float x) {
-    if (abs(x) < 1.0e-9) return 1.0;
-    return sinf(x * PI_F) / (x * PI_F);
 }

--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -18,6 +18,7 @@
 #ifndef LIBRETRODROID_AUDIO_H
 #define LIBRETRODROID_AUDIO_H
 
+#include <array>
 #include <unistd.h>
 #include <oboe/Oboe.h>
 #include "oboe/src/fifo/FifoBuffer.h"
@@ -34,11 +35,22 @@ public:
 
     oboe::DataCallbackResult onAudioReady(oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) override;
 
+    static float sinc(float x);
+    void resample_sinc(const int16_t* source, int32_t inputFrames, int16_t* sink, int32_t sinkFrames);
+    void resample_linear(const int16_t* source, int32_t inputFrames, int16_t* sink, int32_t sinkFrames);
+
     void write(const int16_t *data, size_t frames);
 
 private:
+    static constexpr float PI_F = 3.14159265358979f;
+    static constexpr float MAX_AUDIO_ACCELERATION = 0.02;
+    static constexpr int SINC_RESAMPLING_TAPS = 2;
+
     std::unique_ptr<oboe::FifoBuffer> fifo = nullptr;
+    std::unique_ptr<int16_t[]> audioBuffer = nullptr;
     oboe::ManagedStream stream = nullptr;
+
+    double defaultSampleRate;
 };
 
 }

--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -23,6 +23,8 @@
 #include <oboe/Oboe.h>
 #include "oboe/src/fifo/FifoBuffer.h"
 
+#include "resamplers/linearresampler.h"
+
 namespace LibretroDroid {
 
 class Audio: public oboe::AudioStreamCallback {
@@ -35,20 +37,16 @@ public:
 
     oboe::DataCallbackResult onAudioReady(oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) override;
 
-    static float sinc(float x);
-    void resample_sinc(const int16_t* source, int32_t inputFrames, int16_t* sink, int32_t sinkFrames);
-    void resample_linear(const int16_t* source, int32_t inputFrames, int16_t* sink, int32_t sinkFrames);
-
     void write(const int16_t *data, size_t frames);
 
 private:
-    static constexpr float PI_F = 3.14159265358979f;
-    static constexpr float MAX_AUDIO_ACCELERATION = 0.02;
-    static constexpr int SINC_RESAMPLING_TAPS = 2;
+    // We tolerate a 1% audio speedup or slowdown to avoid buffer overrun or underrun.
+    static constexpr float MAX_AUDIO_ACCELERATION = 0.01;
 
     std::unique_ptr<oboe::FifoBuffer> fifo = nullptr;
     std::unique_ptr<int16_t[]> audioBuffer = nullptr;
     oboe::ManagedStream stream = nullptr;
+    LinearResampler resampler;
 
     double defaultSampleRate;
 };

--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -40,9 +40,11 @@ public:
     void write(const int16_t *data, size_t frames);
 
 private:
-    // We tolerate a 0.5% audio speedup or slowdown to avoid buffer overrun or underrun.
-    static constexpr double MAX_AUDIO_ACCELERATION_FAST = 0.005;
-    static constexpr double MAX_AUDIO_ACCELERATION_SLOW = 0.02;
+    const double MAX_AUDIO_SPEED_PROPORTIONAL = 0.005;
+    const double MAX_AUDIO_SPEED_INTEGRAL = 0.02;
+
+    static int32_t roundToEven(int32_t x);
+    double computeAudioSpeedCoefficient(double dt);
 
     std::unique_ptr<oboe::FifoBuffer> fifo = nullptr;
     std::unique_ptr<int16_t[]> audioBuffer = nullptr;

--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -41,7 +41,8 @@ public:
 
 private:
     // We tolerate a 0.5% audio speedup or slowdown to avoid buffer overrun or underrun.
-    static constexpr float MAX_AUDIO_ACCELERATION = 0.005;
+    static constexpr double MAX_AUDIO_ACCELERATION_FAST = 0.005;
+    static constexpr double MAX_AUDIO_ACCELERATION_SLOW = 0.02;
 
     std::unique_ptr<oboe::FifoBuffer> fifo = nullptr;
     std::unique_ptr<int16_t[]> audioBuffer = nullptr;
@@ -49,6 +50,7 @@ private:
     LinearResampler resampler;
 
     double defaultSampleRate;
+    double errorIntegral = 0.0;
 };
 
 }

--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -40,8 +40,8 @@ public:
     void write(const int16_t *data, size_t frames);
 
 private:
-    // We tolerate a 1% audio speedup or slowdown to avoid buffer overrun or underrun.
-    static constexpr float MAX_AUDIO_ACCELERATION = 0.01;
+    // We tolerate a 0.5% audio speedup or slowdown to avoid buffer overrun or underrun.
+    static constexpr float MAX_AUDIO_ACCELERATION = 0.005;
 
     std::unique_ptr<oboe::FifoBuffer> fifo = nullptr;
     std::unique_ptr<int16_t[]> audioBuffer = nullptr;

--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -50,6 +50,7 @@ private:
     LinearResampler resampler;
 
     double defaultSampleRate;
+    double errorMeasure = 0.0;
     double errorIntegral = 0.0;
 };
 

--- a/libretrodroid/src/main/cpp/resamplers/linearresampler.cpp
+++ b/libretrodroid/src/main/cpp/resamplers/linearresampler.cpp
@@ -1,0 +1,39 @@
+/*
+ *     Copyright (C) 2020  Filippo Scognamiglio
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+#include <algorithm>
+#include "linearresampler.h"
+
+void LibretroDroid::LinearResampler::resample(const int16_t *source, int32_t inputFrames, int16_t *sink, int32_t sinkFrames) {
+    double outputTime = 0;
+    double outputTimeStep = 1.0 / sinkFrames;
+
+    double floatingPart, integerPart;
+
+    while (sinkFrames > 0) {
+        floatingPart = std::modf(outputTime * inputFrames, &integerPart);
+
+        int32_t floorFrame = integerPart;
+        int32_t ceilFrame = std::min(floorFrame + 1, inputFrames - 1);
+
+        *sink++ = source[ceilFrame * 2] * (floatingPart) + source[floorFrame * 2] * (1.0 - floatingPart);
+        *sink++ = source[ceilFrame * 2 + 1] * (floatingPart) + source[floorFrame * 2 + 1] * (1.0 - floatingPart);
+        outputTime += outputTimeStep;
+        sinkFrames--;
+    }
+}

--- a/libretrodroid/src/main/cpp/resamplers/linearresampler.h
+++ b/libretrodroid/src/main/cpp/resamplers/linearresampler.h
@@ -1,0 +1,33 @@
+/*
+ *     Copyright (C) 2020  Filippo Scognamiglio
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBRETRODROID_LINEARRESAMPLER_H
+#define LIBRETRODROID_LINEARRESAMPLER_H
+
+#include "resampler.h"
+
+namespace LibretroDroid {
+class LinearResampler : public LibretroDroid::Resampler {
+public:
+    void resample(const int16_t *source, int32_t inputFrames, int16_t *sink, int32_t sinkFrames) override;
+    LinearResampler() = default;
+    virtual ~LinearResampler() = default;
+};
+}
+
+
+#endif //LIBRETRODROID_LINEARRESAMPLER_H

--- a/libretrodroid/src/main/cpp/resamplers/resampler.h
+++ b/libretrodroid/src/main/cpp/resamplers/resampler.h
@@ -1,0 +1,32 @@
+/*
+ *     Copyright (C) 2020  Filippo Scognamiglio
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBRETRODROID_RESAMPLER_H
+#define LIBRETRODROID_RESAMPLER_H
+
+#include <cstdint>
+
+namespace LibretroDroid {
+
+class Resampler {
+public:
+    virtual void resample(const int16_t* source, int32_t inputFrames, int16_t* sink, int32_t sinkFrames) = 0;
+    virtual ~Resampler() = default;
+};
+}
+
+#endif //LIBRETRODROID_RESAMPLER_H

--- a/libretrodroid/src/main/cpp/resamplers/sincresampler.cpp
+++ b/libretrodroid/src/main/cpp/resamplers/sincresampler.cpp
@@ -1,0 +1,55 @@
+/*
+ *     Copyright (C) 2020  Filippo Scognamiglio
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <algorithm>
+#include "sincresampler.h"
+
+LibretroDroid::SincResampler::SincResampler(const int taps)
+    : halfTaps(taps / 2) { }
+
+void LibretroDroid::SincResampler::resample(const int16_t *source, int32_t inputFrames, int16_t *sink, int32_t sinkFrames) {
+    double outputTime = 0;
+    double outputTimeStep = 1.0f / sinkFrames;
+
+    while (sinkFrames > 0) {
+        int32_t prevInputIndex = outputTime * inputFrames;
+
+        int32_t leftResult = 0;
+        int32_t rightResult = 0;
+        float gain = 0.1;
+
+        auto startFrame = std::max(prevInputIndex - halfTaps + 1, 0);
+        auto endFrame = std::min(prevInputIndex + halfTaps, inputFrames - 1);
+
+        for (int32_t currentInputIndex = startFrame; currentInputIndex <= endFrame; currentInputIndex++) {
+            float sincCoefficient = sinc(outputTime * inputFrames - currentInputIndex);
+            gain += sincCoefficient;
+            leftResult += source[currentInputIndex * 2] * sincCoefficient;
+            rightResult += source[currentInputIndex * 2 + 1] * sincCoefficient;
+        }
+
+        outputTime += outputTimeStep;
+        *sink++ = leftResult / gain;
+        *sink++ = rightResult / gain;
+        sinkFrames--;
+    }
+}
+
+float LibretroDroid::SincResampler::sinc(float x) {
+    if (abs(x) < 1.0e-9) return 1.0;
+    return sinf(x * PI_F) / (x * PI_F);
+}

--- a/libretrodroid/src/main/cpp/resamplers/sincresampler.h
+++ b/libretrodroid/src/main/cpp/resamplers/sincresampler.h
@@ -1,0 +1,40 @@
+/*
+ *     Copyright (C) 2020  Filippo Scognamiglio
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBRETRODROID_SINCRESAMPLER_H
+#define LIBRETRODROID_SINCRESAMPLER_H
+
+#include "resampler.h"
+
+namespace LibretroDroid {
+class SincResampler : public LibretroDroid::Resampler {
+public:
+    void resample(const int16_t *source, int32_t inputFrames, int16_t *sink, int32_t sinkFrames) override;
+    SincResampler(const int taps);
+    ~SincResampler() = default;
+
+private:
+    static float sinc(float x);
+
+private:
+    static constexpr float PI_F = 3.14159265358979f;
+    int halfTaps;
+};
+}
+
+
+#endif //LIBRETRODROID_SINCRESAMPLER_H


### PR DESCRIPTION
This should overall reduce audio glitches and remove offsets when v-sync timings are too different from the screen refresh rate.