### PR TITLE
Add method to load game from RAM

### DIFF
--- a/app/src/main/java/com/swordfish/libretrodroid/SampleActivity.kt
+++ b/app/src/main/java/com/swordfish/libretrodroid/SampleActivity.kt
@@ -51,8 +51,6 @@ class SampleActivity : AppCompatActivity() {
                  */
                 "${filesDir}/example.gba",
 
-                null,
-
                 /* (Optional) System directory */
                 filesDir.absolutePath,
 

--- a/app/src/main/java/com/swordfish/libretrodroid/SampleActivity.kt
+++ b/app/src/main/java/com/swordfish/libretrodroid/SampleActivity.kt
@@ -37,12 +37,6 @@ class SampleActivity : AppCompatActivity() {
                 this,
 
                 /*
-                 * The path to the ROM to load.
-                 * Example: /data/data/<package-id>/files/example.gba
-                 */
-                "${filesDir}/example.gba",
-
-                /*
                  * The name of the LibRetro core to load.
                  * The typical location that libraries should be stored in is
                  * app/src/main/jniLibs/<ABI>/
@@ -50,6 +44,14 @@ class SampleActivity : AppCompatActivity() {
                  * ABI can be arm64-v8a, armeabi-v7a, x86, or x86_64
                  */
                 "mgba_libretro_android.so",
+
+                /*
+                 * The path to the ROM to load.
+                 * Example: /data/data/<package-id>/files/example.gba
+                 */
+                "${filesDir}/example.gba",
+
+                null,
 
                 /* (Optional) System directory */
                 filesDir.absolutePath,

--- a/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
+++ b/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
@@ -38,18 +38,56 @@ import javax.microedition.khronos.egl.EGLConfig
 import javax.microedition.khronos.opengles.GL10
 import kotlin.properties.Delegates
 
-class GLRetroView(
-    context: Context,
-    private val coreFilePath: String,
-    private val gameFilePath: String?,
-    private val gameFileBytes: ByteArray?,
-    private val systemDirectory: String = context.filesDir.absolutePath,
-    private val savesDirectory: String = context.filesDir.absolutePath,
-    private val variables: Array<Variable> = arrayOf(),
-    private var saveRAMState: ByteArray? = null,
-    private val shader: Int = LibretroDroid.SHADER_DEFAULT,
-    private val rumbleEventsEnabled: Boolean = true
-) : AspectRatioGLSurfaceView(context), LifecycleObserver {
+class GLRetroView(context: Context) : AspectRatioGLSurfaceView(context), LifecycleObserver {
+    private lateinit var coreFilePath: String
+    private var gameFilePath: String? = null
+    private var gameFileBytes: ByteArray? = null
+    private var systemDirectory: String = context.filesDir.absolutePath
+    private var savesDirectory: String = context.filesDir.absolutePath
+    private var variables: Array<Variable> = arrayOf()
+    private var saveRAMState: ByteArray? = null
+    private var shader: Int = LibretroDroid.SHADER_DEFAULT
+    private var rumbleEventsEnabled: Boolean = true
+
+    constructor(context: Context,
+                coreFilePath: String,
+                gameFilePath: String,
+                systemDirectory: String = context.filesDir.absolutePath,
+                savesDirectory: String = context.filesDir.absolutePath,
+                variables: Array<Variable> = arrayOf(),
+                saveRAMState: ByteArray? = null,
+                shader: Int = LibretroDroid.SHADER_DEFAULT,
+                rumbleEventsEnabled: Boolean = true) : this(context)
+    {
+        this.coreFilePath = coreFilePath
+        this.gameFilePath = gameFilePath
+        this.systemDirectory = systemDirectory
+        this.savesDirectory = savesDirectory
+        this.variables = variables
+        this.saveRAMState = saveRAMState
+        this.shader = shader
+        this.rumbleEventsEnabled = rumbleEventsEnabled
+    }
+
+    constructor(context: Context,
+                coreFilePath: String,
+                gameFileBytes: ByteArray,
+                systemDirectory: String = context.filesDir.absolutePath,
+                savesDirectory: String = context.filesDir.absolutePath,
+                variables: Array<Variable> = arrayOf(),
+                saveRAMState: ByteArray? = null,
+                shader: Int = LibretroDroid.SHADER_DEFAULT,
+                rumbleEventsEnabled: Boolean = true) : this(context)
+    {
+        this.coreFilePath = coreFilePath
+        this.gameFileBytes = gameFileBytes
+        this.systemDirectory = systemDirectory
+        this.savesDirectory = savesDirectory
+        this.variables = variables
+        this.saveRAMState = saveRAMState
+        this.shader = shader
+        this.rumbleEventsEnabled = rumbleEventsEnabled
+    }
 
     var audioEnabled: Boolean by Delegates.observable(true) { _, _, value ->
         LibretroDroid.setAudioEnabled(value)

--- a/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
+++ b/libretrodroid/src/main/java/com/swordfish/libretrodroid/GLRetroView.kt
@@ -41,7 +41,8 @@ import kotlin.properties.Delegates
 class GLRetroView(
     context: Context,
     private val coreFilePath: String,
-    private val gameFilePath: String,
+    private val gameFilePath: String?,
+    private val gameFileBytes: ByteArray?,
     private val systemDirectory: String = context.filesDir.absolutePath,
     private val savesDirectory: String = context.filesDir.absolutePath,
     private val variables: Array<Variable> = arrayOf(),
@@ -268,7 +269,10 @@ class GLRetroView(
     // These functions are called from the GL thread.
     private fun initializeCore() {
         if (gameLoaded) return
-        LibretroDroid.loadGame(gameFilePath)
+        if (gameFilePath != null)
+            LibretroDroid.loadGameFromPath(gameFilePath)
+        else if (gameFileBytes != null)
+            LibretroDroid.loadGameFromBytes(gameFileBytes)
         saveRAMState?.let {
             LibretroDroid.unserializeSRAM(saveRAMState)
             saveRAMState = null

--- a/libretrodroid/src/main/java/com/swordfish/libretrodroid/LibretroDroid.java
+++ b/libretrodroid/src/main/java/com/swordfish/libretrodroid/LibretroDroid.java
@@ -34,7 +34,8 @@ class LibretroDroid {
     public static final int SHADER_SHARP = 3;
 
     public static native void create(int GLESVersion, String coreFilePath, String systemDir, String savesDir, Variable[] variables, int shaderType, float refreshRate, String language);
-    public static native void loadGame(String gameFilePath);
+    public static native void loadGameFromPath(String gameFilePath);
+    public static native void loadGameFromBytes(byte[] gameFileBytes);
     public static native void resume();
 
     public static native void onSurfaceCreated();


### PR DESCRIPTION
This allows us to load games directly from a ByteArray, which is very
much ideal when bundling game files in the assets directory of the app.
Since assets cannot be accessed directly, they must be first copied out
of the app. We can avoid this by loading the game directly from a
ByteArray.

It is understandable if you do not want to merge this change into the main repo since it would require devs to explicitly specify `null` to the gameFileBytes parameter. Let me know your thoughts.