### PR TITLE
Allow audio to play while fast forwarding

### DIFF
--- a/libretrodroid/src/main/cpp/audio.cpp
+++ b/libretrodroid/src/main/cpp/audio.cpp
@@ -57,8 +57,14 @@ void LibretroDroid::Audio::write(const int16_t *data, size_t frames) {
     fifo->write(data, size);
 }
 
+void LibretroDroid::Audio::setSampleRateMultiplier(const double multiplier) {
+    sampleRateMultiplier = multiplier;
+}
+
 oboe::DataCallbackResult LibretroDroid::Audio::onAudioReady(oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) {
-    double finalSampleRate = defaultSampleRate * computeAudioSpeedCoefficient(0.001 * numFrames);
+    double finalSampleRate = defaultSampleRate *
+            computeAudioSpeedCoefficient(0.001 * numFrames) *
+            sampleRateMultiplier;
 
     int32_t adjustedTotalFrames = numFrames * finalSampleRate;
 

--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -38,6 +38,7 @@ public:
     oboe::DataCallbackResult onAudioReady(oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) override;
 
     void write(const int16_t *data, size_t frames);
+    void setSampleRateMultiplier(const double multiplier);
 
 private:
     const double MAX_AUDIO_SPEED_PROPORTIONAL = 0.005;
@@ -54,6 +55,7 @@ private:
     double defaultSampleRate;
     double errorMeasure = 0.0;
     double errorIntegral = 0.0;
+    double sampleRateMultiplier = 1.0;
 };
 
 }

--- a/libretrodroid/src/main/cpp/libretrodroid.cpp
+++ b/libretrodroid/src/main/cpp/libretrodroid.cpp
@@ -77,7 +77,7 @@ void callback_audio_sample(int16_t left, int16_t right) {
 }
 
 size_t callback_set_audio_sample_batch(const int16_t *data, size_t frames) {
-    if (audio != nullptr && audioEnabled && !fastForwardEnabled) {
+    if (audio != nullptr && audioEnabled) {
         audio->write(data, frames);
     }
     return frames;

--- a/libretrodroid/src/main/cpp/libretrodroid.cpp
+++ b/libretrodroid/src/main/cpp/libretrodroid.cpp
@@ -567,6 +567,7 @@ JNIEXPORT void JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_setRumbleE
 
 JNIEXPORT void JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_setFastForwardEnabled(JNIEnv * env, jobject obj, jboolean enabled) {
     fastForwardEnabled = enabled;
+    audio->setSampleRateMultiplier(enabled ? 2.0 : 1.0);
 }
 
 JNIEXPORT void JNICALL Java_com_swordfish_libretrodroid_LibretroDroid_setAudioEnabled(JNIEnv * env, jobject obj, jboolean enabled) {


### PR DESCRIPTION
I think it's better to play the audio even if it is distorted. It lets
users gauge how fast the game is playing.