### PR TITLE
Target a constant audio latency

### DIFF
--- a/libretrodroid/src/main/cpp/audio.h
+++ b/libretrodroid/src/main/cpp/audio.h
@@ -43,6 +43,7 @@ public:
 private:
     const double MAX_AUDIO_SPEED_PROPORTIONAL = 0.005;
     const double MAX_AUDIO_SPEED_INTEGRAL = 0.02;
+    const int32_t AUDIO_LATENCY_MAX_MS = 60;
 
     static int32_t roundToEven(int32_t x);
     double computeAudioSpeedCoefficient(double dt);


### PR DESCRIPTION
This fixes stuttering when using high-latency headphones as well as
reduces the in-game audio latency significantly.

By default, I set the max latency ms to 60ms, but that is up to you to configure. I feel that 125ms is far too high for undetectable latency.