### PR TITLE
Switch to a low latency audio stream

### DIFF
--- a/libretrodroid/src/main/cpp/audio.cpp
+++ b/libretrodroid/src/main/cpp/audio.cpp
@@ -35,7 +35,7 @@ LibretroDroid::Audio::Audio(int32_t sampleRate) {
     builder.setDirection(oboe::Direction::Output);
     builder.setFormat(oboe::AudioFormat::I16);
     builder.setCallback(this);
-    builder.setFramesPerCallback(sampleRateBufferSize / 8);
+    builder.setPerformanceMode(oboe::PerformanceMode::LowLatency);
 
     oboe::Result result = builder.openManagedStream(stream);
     if (result != oboe::Result::OK) {


### PR DESCRIPTION
As a side effect, we no longer need to specify a frame size per
callback, since the LowLatency stream ends up fixing this issue
entirely. Latency on Mega Man 3 with the nestopia core is able to hit as
low as 45ms audio latency, even when the maximum latency is targeted at
120ms+.

Definitely give this a shot. It's absolutely wonderful on my end.