### PR TITLE
Ignore platform specific gradle config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ app/*.iml
 .gradle
 .idea
 *.iml
+local.properties

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri Oct 11 16:06:44 CEST 2019
-sdk.dir=/home/swordfish/Android/Sdk


### PR DESCRIPTION
The local.properties file makes it difficult to build.