### PR TITLE
SampleActivity: Fix typo in default core path

### DIFF
--- a/app/src/main/java/com/swordfish/libretrodroid/SampleActivity.kt
+++ b/app/src/main/java/com/swordfish/libretrodroid/SampleActivity.kt
@@ -56,7 +56,7 @@ class SampleActivity : AppCompatActivity() {
              *
              * ABI can be arm64-v8a, armeabi-v7a, x86, or x86_64
              */
-            coreFilePath = "mgba_libretro_android.so"
+            coreFilePath = "libmgba_libretro_android.so"
 
             /*
              * The path to the ROM to load.


### PR DESCRIPTION
Fixes a typo, since the mgba core is prefixed with "lib", and crashes without specifying that in the core path. Tested on my end.